### PR TITLE
Improve functionality of timers

### DIFF
--- a/simavr/cores/sim_mega32u4.c
+++ b/simavr/cores/sim_mega32u4.c
@@ -331,6 +331,7 @@ const struct mcu_t {
 				.r_ocrh = OCR1AH,	// 16 bits timers have two bytes of it
 				.com = AVR_IO_REGBITS(TCCR1A, COM1A0, 0x3),
 				.com_pin = AVR_IO_REGBIT(PORTB, 5),
+                                .foc = AVR_IO_REGBIT(TCCR1C, FOC1A),
 				.interrupt = {
 					.enable = AVR_IO_REGBIT(TIMSK1, OCIE1A),
 					.raised = AVR_IO_REGBIT(TIFR1, OCF1A),
@@ -342,6 +343,7 @@ const struct mcu_t {
 				.r_ocrh = OCR1BH,
 				.com = AVR_IO_REGBITS(TCCR1A, COM1B0, 0x3),
 				.com_pin = AVR_IO_REGBIT(PORTB, 6),
+                                .foc = AVR_IO_REGBIT(TCCR1C, FOC1B),
 				.interrupt = {
 					.enable = AVR_IO_REGBIT(TIMSK1, OCIE1B),
 					.raised = AVR_IO_REGBIT(TIFR1, OCF1B),

--- a/simavr/sim/avr_timer.c
+++ b/simavr/sim/avr_timer.c
@@ -120,6 +120,11 @@ avr_timer_comp_on_tov(
 	uint8_t mode = avr_regbit_get(avr, p->comp[comp].com);
 	avr_irq_t * irq = &p->io.irq[TIMER_IRQ_OUT_COMP + comp];
 
+        // only PWM modes have special behaviour on overflow
+        if((p->wgm_op_mode_kind != avr_timer_wgm_pwm) &&
+           (p->wgm_op_mode_kind != avr_timer_wgm_fast_pwm))
+                return;
+
 	switch (mode) {
 		case avr_timer_com_normal: // Normal mode
 			break;

--- a/simavr/sim/avr_timer.c
+++ b/simavr/sim/avr_timer.c
@@ -83,23 +83,27 @@ avr_timer_comp(
 	uint8_t mode = avr_regbit_get(avr, p->comp[comp].com);
 	avr_irq_t * irq = &p->io.irq[TIMER_IRQ_OUT_COMP + comp];
 
+        uint32_t flags = 0;
+        if (p->comp[comp].com_pin.reg)	// we got a physical pin
+                flags |= AVR_IOPORT_OUTPUT;
+        AVR_LOG(avr, LOG_TRACE, "Timer comp: irq %p, mode %d @%d\n", irq, mode, when);
 	switch (mode) {
 		case avr_timer_com_normal: // Normal mode OCnA disconnected
 			break;
 		case avr_timer_com_toggle: // Toggle OCnA on compare match
 			if (p->comp[comp].com_pin.reg)	// we got a physical pin
 				avr_raise_irq(irq,
-						AVR_IOPORT_OUTPUT |
+						flags |
 						(avr_regbit_get(avr, p->comp[comp].com_pin) ? 0 : 1));
 			else // no pin, toggle the IRQ anyway
 				avr_raise_irq(irq,
 						p->io.irq[TIMER_IRQ_OUT_COMP + comp].value ? 0 : 1);
 			break;
 		case avr_timer_com_clear:
-			avr_raise_irq(irq, 0);
+			avr_raise_irq(irq, flags | 0);
 			break;
 		case avr_timer_com_set:
-			avr_raise_irq(irq, 1);
+			avr_raise_irq(irq, flags | 1);
 			break;
 	}
 

--- a/simavr/sim/avr_timer.h
+++ b/simavr/sim/avr_timer.h
@@ -114,6 +114,7 @@ typedef struct avr_timer_comp_t {
 		avr_regbit_t		com;			// comparator output mode registers
 		avr_regbit_t		com_pin;		// where comparator output is connected
 		uint64_t			comp_cycles;
+                avr_regbit_t            foc;                    // "force compare match" strobe
 } avr_timer_comp_t, *avr_timer_comp_p;
 
 enum {


### PR DESCRIPTION

I found a few discrepancies between `simavr` and the ATmega32U4 datasheet regarding the behaviour of the "output compare" outputs, so I've had a go at fixing them.
I'll admit I'm not very familiar with `simavr` or these microcontrollers, so I hope I haven't broken anything.


Original author: MikePlayle
