### PR TITLE
Add missing MKDIR before INSTALL

### DIFF
--- a/examples/parts/Makefile
+++ b/examples/parts/Makefile
@@ -50,6 +50,7 @@ endif
 install: obj ${target}
 	$(MKDIR) $(DESTDIR)/include/simavr/parts
 	$(INSTALL) -m644 *.h $(DESTDIR)/include/simavr/parts/
+	$(MKDIR) $(DESTDIR)/lib/pkgconfig
 	$(INSTALL) ${OBJ}/libsimavrparts.a $(DESTDIR)/lib/
 	sed -e "s|PREFIX|${PREFIX}|g" -e "s|VERSION|${SIMAVR_VERSION}|g" \
 		simavrparts.pc >$(DESTDIR)/lib/pkgconfig/simavrparts.pc


### PR DESCRIPTION

This also fix the issue https://github.com/osx-cross/homebrew-avr/issues/82
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

Original author: patrickelectric
