### PR TITLE
Add shadow register for UBRRH to keep it separate from UCSRC

### DIFF
--- a/simavr/sim/avr_uart.h
+++ b/simavr/sim/avr_uart.h
@@ -113,6 +113,7 @@ typedef struct avr_uart_t {
 
 	avr_regbit_t	ubrrl;
 	avr_regbit_t	ubrrh;
+	uint8_t		ubrrh_shadow;
 
 	avr_int_vector_t rxc;
 	avr_int_vector_t txc;


### PR DESCRIPTION

In e.g. ATmega8 UBRRH and UCSRC registers share the same I/O location.
Bit URSEL decides in which physical register written data should go.
As there are now more registers then I/O locations, "shadow" versions of
certain regbit functions that store to a pointer ("shadow register")
instead of the main registers in avr->data[] were introduced.
UBRRH was moved into a shadow register, while UCSRC stays a regular register.
Therefore, writes to UBRRH/UCSRC with URSEL bit set do not set the baudrate
falsely anymore.

Original author: StefanKrupop
